### PR TITLE
Main bumped embassy sync

### DIFF
--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -107,23 +107,19 @@ optional = true
 #
 
 [dependencies.embassy-usb]
-git = "https://github.com/embassy-rs/embassy/blob/main/embassy-usb"
-rev = "cf0d227cca92a80e85575154d380d1ff73fb32cf"
+git = "https://github.com/jucr-io/embassy/"
 optional = true
 
 [dependencies.embassy-usb-driver]
-git = "https://github.com/embassy-rs/embassy/blob/main/embassy-usb-driver"
-rev = "597315873dbef394ae4cefe0af740fcb1bb951e0"
+git = "https://github.com/jucr-io/embassy/"
 optional = true
 
 [dependencies.embassy-sync]
-git = "https://github.com/embassy-rs/embassy/blob/main/embassy-sync"
-rev = "cf0d227cca92a80e85575154d380d1ff73fb32cf"
+git = "https://github.com/jucr-io/embassy/"
 optional = true
 
 [dependencies.embassy-executor]
-git = "https://github.com/embassy-rs/embassy/blob/main/embassy-executor"
-rev = "2c42463205dae7e38535fb18f58e872df99e125a"
+git = "https://github.com/jucr-io/embassy/"
 optional = true
 
 [dependencies.static_cell]

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -107,23 +107,27 @@ optional = true
 #
 
 [dependencies.embassy-usb]
-version = "0.2"
+git = "https://github.com/embassy-rs/embassy/blob/main/embassy-usb"
+rev = "cf0d227cca92a80e85575154d380d1ff73fb32cf"
 optional = true
 
 [dependencies.embassy-usb-driver]
-version = "0.1"
+git = "https://github.com/embassy-rs/embassy/blob/main/embassy-usb-driver"
+rev = "597315873dbef394ae4cefe0af740fcb1bb951e0"
 optional = true
 
 [dependencies.embassy-sync]
-version = "0.6"
+git = "https://github.com/embassy-rs/embassy/blob/main/embassy-sync"
+rev = "cf0d227cca92a80e85575154d380d1ff73fb32cf"
+optional = true
+
+[dependencies.embassy-executor]
+git = "https://github.com/embassy-rs/embassy/blob/main/embassy-executor"
+rev = "2c42463205dae7e38535fb18f58e872df99e125a"
 optional = true
 
 [dependencies.static_cell]
 version = "2.1"
-optional = true
-
-[dependencies.embassy-executor]
-version = "0.5"
 optional = true
 
 [dev-dependencies]

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -115,7 +115,7 @@ version = "0.1"
 optional = true
 
 [dependencies.embassy-sync]
-version = "0.5"
+version = "0.6"
 optional = true
 
 [dependencies.static_cell]


### PR DESCRIPTION
We want to stabilize software using embassy and postcard. Given that Postcard waits with breaking changes (pr #30 iirc) and embassy has a release to crates.io cadence of 6 months - it was decided to use frozen embassy git revisions, and update postcard too.