### PR TITLE
switch to latest postcard git

### DIFF
--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 cobs = { version = "0.2.3", optional = true, default-features = false }
 defmt = { version = "0.3.5", optional = true }
 heapless = "0.8.0"
-postcard = { version = "1.0.8", features = ["experimental-derive"] }
+postcard = { git = "ssh://git@github.com/jamesmunns/postcard", features = ["experimental-derive"] }
 serde = { version = "1.0.192", default-features = false, features = ["derive"] }
 
 #

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 cobs = { version = "0.2.3", optional = true, default-features = false }
 defmt = { version = "0.3.5", optional = true }
 heapless = "0.8.0"
-postcard = { git = "ssh://git@github.com/jamesmunns/postcard", features = ["experimental-derive"] }
+postcard = { git = "ssh://git@github.com/jamesmunns/postcard", rev = "93d4ba23760edabf408af26dc9dbc9bec0a8ade8", features = ["experimental-derive"] }
 serde = { version = "1.0.192", default-features = false, features = ["derive"] }
 
 #


### PR DESCRIPTION
We are using heapless 0.8.0 in the project.
Postcard-rpc was pulling heapless 0.7.17 and errors are observed when heapless string is used in a struct with Schema macro.

Patch tested, works.